### PR TITLE
Update polyfill to point at the public proxy URL.

### DIFF
--- a/polyfill/ballista-polyfill.js
+++ b/polyfill/ballista-polyfill.js
@@ -27,8 +27,7 @@
 // polyfill by mkruisselbrink and reillyeon:
 // https://github.com/mkruisselbrink/navigator-connect
 
-// TODO(mgiuca): Move this to a fixed public location.
-var kProxySite = 'http://localhost:8080';
+var kProxySite = 'https://chromium-ballista.appspot.com';
 
 // The URL of the proxy app, which provides the handler chooser and routes
 // actions through to the chosen handler.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -16,6 +16,10 @@ required in a browser that actually implements Ballista).
 The proxy is now running at [http://localhost:8080](http://localhost:8080).
 Visiting that site allows you to view, add and remove handler registrations.
 
+To test the polyfill against your local version of the proxy, update
+`polyfill/ballista-polyfill.js`, changing `kProxySite` to
+`"http://localhost:8080"`.
+
 ## Details
 
 The proxy is an implementation detail which neither users nor developers need to


### PR DESCRIPTION
After this change, all websites using the proxy will register / lookup handlers from the IndexedDB associated with the central domain chromium-ballista.appspot.com.

Also adds a note to explain how to test against your own local proxy site.
