### PR TITLE
Requester: Rewrote app to present a file storage interface

### DIFF
--- a/common/common.css
+++ b/common/common.css
@@ -24,3 +24,7 @@ body {
 #contents_textfield {
   width: 600px;
 }
+
+.edit-button {
+  margin-bottom: 10px;
+}

--- a/common/common.css
+++ b/common/common.css
@@ -25,6 +25,10 @@ body {
   width: 600px;
 }
 
+.compact-mdl-textfield {
+  padding: 0;
+}
+
 .edit-button {
   margin-bottom: 10px;
 }

--- a/common/common.js
+++ b/common/common.js
@@ -27,6 +27,19 @@ function readBlobAsText(blob) {
   });
 }
 
+// Creates a <tr> element for a table with simple text in each cell (MDL style).
+// |cells| is an array of strings.
+function createTableRow(cells) {
+  var tr = document.createElement('tr');
+  for (var i = 0; i < cells.length; i++) {
+    var td = document.createElement('td');
+    td.setAttribute('class', 'mdl-data-table__cell--non-numeric');
+    td.appendChild(document.createTextNode(cells[i]));
+    tr.appendChild(td);
+  }
+  return tr;
+}
+
 // Call this to re-run the MDL upgrade step on a table (to regenerate the
 // checkboxes). This should be called whenever |table| is changed.
 function reUpgradeTable(table) {

--- a/common/common.js
+++ b/common/common.js
@@ -42,13 +42,14 @@ function createTableRow(cells) {
 
 // Call this to re-run the MDL upgrade step on a table (to regenerate the
 // checkboxes). This should be called whenever |table| is changed.
-function reUpgradeTable(table) {
+function reUpgradeTable(table, selectionChangedCallback) {
   // Delete all the checkbox cells.
   var trs = table.querySelectorAll('tr');
   for (var i = 0; i < trs.length; i++) {
     var tr = trs[i];
     var firstCell = tr.querySelector('th,td');
-    if (firstCell.querySelector('input') != null)
+    var firstCellInput = firstCell.querySelector('input');
+    if (firstCellInput != null && firstCellInput.type == 'checkbox')
       tr.removeChild(firstCell);
   }
 
@@ -64,7 +65,7 @@ function reUpgradeTable(table) {
     var tr = trs[i];
     var firstCell = tr.querySelector('th,td');
     var checkbox = firstCell.querySelector('input');
-    if (checkbox != null)
-      checkbox.addEventListener('change', selectionChanged);
+    if (checkbox != null && selectionChangedCallback != null)
+      checkbox.addEventListener('change', selectionChangedCallback);
   }
 }

--- a/common/common.js
+++ b/common/common.js
@@ -26,3 +26,32 @@ function readBlobAsText(blob) {
     reader.readAsText(blob);
   });
 }
+
+// Call this to re-run the MDL upgrade step on a table (to regenerate the
+// checkboxes). This should be called whenever |table| is changed.
+function reUpgradeTable(table) {
+  // Delete all the checkbox cells.
+  var trs = table.querySelectorAll('tr');
+  for (var i = 0; i < trs.length; i++) {
+    var tr = trs[i];
+    var firstCell = tr.querySelector('th,td');
+    if (firstCell.querySelector('input') != null)
+      tr.removeChild(firstCell);
+  }
+
+  // Force MDL to regenerate the checkbox cells. (The removal of data-upgraded
+  // is required due to
+  // https://github.com/google/material-design-lite/issues/984; this is a
+  // proposed work-around.)
+  table.removeAttribute('data-upgraded');
+  componentHandler.upgradeElement(table);
+
+  // Add event handlers to the checkboxes.
+  for (var i = 0; i < trs.length; i++) {
+    var tr = trs[i];
+    var firstCell = tr.querySelector('th,td');
+    var checkbox = firstCell.querySelector('input');
+    if (checkbox != null)
+      checkbox.addEventListener('change', selectionChanged);
+  }
+}

--- a/proxy.yaml
+++ b/proxy.yaml
@@ -39,3 +39,7 @@ handlers:
 - url: /icon
   static_dir: proxy/icon
   secure: always
+
+- url: /common
+  static_dir: common
+  secure: always

--- a/proxy/index.html
+++ b/proxy/index.html
@@ -21,6 +21,7 @@ limitations under the License.
     <script src="https://storage.googleapis.com/code.getmdl.io/1.0.5/material.min.js"></script>
     <script type="text/javascript" src="index.js"></script>
     <script type="text/javascript" src="registry.js"></script>
+    <script type="text/javascript" src="common/common.js"></script>
     <link rel="icon" sizes="32x32" href="icon/32.png">
     <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.5/material.blue_grey-deep_purple.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -51,35 +51,6 @@ function createTableRow(cells) {
   return tr;
 }
 
-// Call this to re-run the MDL upgrade step on a table (to regenerate the
-// checkboxes). This should be called whenever |table| is changed.
-function reUpgradeTable(table) {
-  // Delete all the checkbox cells.
-  var trs = table.querySelectorAll('tr');
-  for (var i = 0; i < trs.length; i++) {
-    var tr = trs[i];
-    var firstCell = tr.querySelector('th,td');
-    if (firstCell.querySelector('input') != null)
-      tr.removeChild(firstCell);
-  }
-
-  // Force MDL to regenerate the checkbox cells. (The removal of data-upgraded
-  // is required due to
-  // https://github.com/google/material-design-lite/issues/984; this is a
-  // proposed work-around.)
-  table.removeAttribute('data-upgraded');
-  componentHandler.upgradeElement(table);
-
-  // Add event handlers to the checkboxes.
-  for (var i = 0; i < trs.length; i++) {
-    var tr = trs[i];
-    var firstCell = tr.querySelector('th,td');
-    var checkbox = firstCell.querySelector('input');
-    if (checkbox != null)
-      checkbox.addEventListener('change', selectionChanged);
-  }
-}
-
 function generateTableRows() {
   var table = document.getElementById('handler_table');
   var tbody = table.querySelector('tbody');

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -38,19 +38,6 @@ function selectionChanged() {
     deleteButton.setAttribute('disabled', '');
 }
 
-// Creates a <tr> element for a table with simple text in each cell. |cells| is
-// an array of strings.
-function createTableRow(cells) {
-  var tr = document.createElement('tr');
-  for (var i = 0; i < cells.length; i++) {
-    var td = document.createElement('td');
-    td.setAttribute('class', 'mdl-data-table__cell--non-numeric');
-    td.appendChild(document.createTextNode(cells[i]));
-    tr.appendChild(td);
-  }
-  return tr;
-}
-
 function generateTableRows() {
   var table = document.getElementById('handler_table');
   var tbody = table.querySelector('tbody');

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -51,11 +51,11 @@ function createTableRow(cells) {
   return tr;
 }
 
-// Call this to re-run the MDL upgrade step on the table (to regenerate the
-// checkboxes). This should be called whenever the table is changed.
-function reUpgradeTable() {
+// Call this to re-run the MDL upgrade step on a table (to regenerate the
+// checkboxes). This should be called whenever |table| is changed.
+function reUpgradeTable(table) {
   // Delete all the checkbox cells.
-  var trs = document.querySelectorAll('#handler_table tr');
+  var trs = table.querySelectorAll('tr');
   for (var i = 0; i < trs.length; i++) {
     var tr = trs[i];
     var firstCell = tr.querySelector('th,td');
@@ -67,7 +67,6 @@ function reUpgradeTable() {
   // is required due to
   // https://github.com/google/material-design-lite/issues/984; this is a
   // proposed work-around.)
-  var table = document.getElementById('handler_table');
   table.removeAttribute('data-upgraded');
   componentHandler.upgradeElement(table);
 
@@ -82,7 +81,8 @@ function reUpgradeTable() {
 }
 
 function generateTableRows() {
-  var tbody = document.querySelector('#handler_table tbody');
+  var table = document.getElementById('handler_table');
+  var tbody = table.querySelector('tbody');
   while (tbody.firstChild)
     tbody.removeChild(tbody.firstChild);
 
@@ -95,7 +95,7 @@ function generateTableRows() {
         tbody.appendChild(tr);
       }
       db.close();
-      reUpgradeTable();
+      reUpgradeTable(table);
     }, () => db.close());
   });
 }

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -53,7 +53,7 @@ function generateTableRows() {
         tbody.appendChild(tr);
       }
       db.close();
-      reUpgradeTable(table);
+      reUpgradeTable(table, selectionChanged);
     }, () => db.close());
   });
 }

--- a/requester/index.html
+++ b/requester/index.html
@@ -36,6 +36,43 @@ limitations under the License.
       </header>
       <main class="mdl-layout__content">
         <div class="mdl-grid">
+          <div class="mdl-cell--12-col">
+            <table class="mdl-data-table mdl-js-data-table mdl-data-table--selectable mdl-shadow--2dp" id="file_table">
+              <thead>
+                <tr>
+                  <th class="mdl-data-table__cell--non-numeric">Filename</th>
+                  <th class="mdl-data-table__cell--non-numeric"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="mdl-data-table__cell--non-numeric">
+                    <input class="mdl-textfield__input" type="text" id="filename_textfield" value="test.txt" />
+                  </td>
+                  <td class="mdl-data-table__cell--non-numeric">
+                    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect edit-button" id="edit_button">Open</button>
+                    <div class="mdl-tooltip" for="edit_button">
+                      Open up the file in an external editor using <strong>Ballista</strong>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="mdl-cell mdl-cell--1-col">
+            <button class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-js-ripple-effect mdl-button--colored" id="delete_files" disabled>
+              <i class="material-icons">delete</i>
+            </button>
+            <div class="mdl-tooltip" for="delete_files">Delete selected files</div>
+          </div>
+          <div class="mdl-cell mdl-cell--1-col">
+            <button class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-js-ripple-effect mdl-button--colored" id="new_file">
+                <i class="material-icons">add</i>
+            </button>
+            <div class="mdl-tooltip" for="new_file">Add new file</div>
+          </div>
+        </div>
+        <div class="mdl-grid">
           <div class="mdl-cell mdl-cell--12-col">
             This text field represents the contents of a file in cloud storage:
           </div>

--- a/requester/index.html
+++ b/requester/index.html
@@ -68,15 +68,15 @@ limitations under the License.
             <div class="mdl-tooltip" for="new_file">Add new file</div>
           </div>
         </div>
-        <div class="mdl-grid">
+        <div class="mdl-grid" id="preview_label" style="display: none">
           <div class="mdl-cell mdl-cell--12-col">
             Preview of selected file:
           </div>
         </div>
-        <div class="mdl-grid">
+        <div class="mdl-grid" id="preview_box" style="display: none">
           <div class="mdl-cell mdl-cell--4-col">
             <div class="mdl-textfield mdl-js-textfield">
-              <textarea id="contents_textfield" class="mdl-textfield__input" type="text" rows="15" style="display: none" readonly></textarea>
+              <textarea id="contents_textfield" class="mdl-textfield__input" type="text" rows="15" readonly></textarea>
             </div>
           </div>
         </div>

--- a/requester/index.html
+++ b/requester/index.html
@@ -44,19 +44,7 @@ limitations under the License.
                   <th class="mdl-data-table__cell--non-numeric"></th>
                 </tr>
               </thead>
-              <tbody>
-                <tr>
-                  <td class="mdl-data-table__cell--non-numeric">
-                    <input class="mdl-textfield__input" type="text" id="filename_textfield" value="test.txt" />
-                  </td>
-                  <td class="mdl-data-table__cell--non-numeric">
-                    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect edit-button" id="edit_button">Open</button>
-                    <div class="mdl-tooltip" for="edit_button">
-                      Open up the file in an external editor using <strong>Ballista</strong>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
+              <tbody></tbody>
             </table>
           </div>
           <div class="mdl-cell mdl-cell--1-col">

--- a/requester/index.html
+++ b/requester/index.html
@@ -36,6 +36,14 @@ limitations under the License.
       </header>
       <main class="mdl-layout__content">
         <div class="mdl-grid">
+          <div class="mdl-cell mdl-cell--12-col">
+            Test out the <a href="https://github.com/chromium/ballista">Ballista
+              API</a> by creating a file, then editing it in an external
+            editor.<br /><strong>Note: These files are not saved anywhere; this
+              is just a demo.</strong>
+          </div>
+        </div>
+        <div class="mdl-grid">
           <div class="mdl-cell--12-col">
             <table class="mdl-data-table mdl-js-data-table mdl-data-table--selectable mdl-shadow--2dp" id="file_table">
               <thead>

--- a/requester/index.html
+++ b/requester/index.html
@@ -62,33 +62,14 @@ limitations under the License.
         </div>
         <div class="mdl-grid">
           <div class="mdl-cell mdl-cell--12-col">
-            This text field represents the contents of a file in cloud storage:
+            Preview of selected file:
           </div>
         </div>
         <div class="mdl-grid">
           <div class="mdl-cell mdl-cell--4-col">
             <div class="mdl-textfield mdl-js-textfield">
-              <textarea id="contents_textfield" class="mdl-textfield__input" type="text" rows="15">The file contents.</textarea>
+              <textarea id="contents_textfield" class="mdl-textfield__input" type="text" rows="15" style="display: none" readonly></textarea>
             </div>
-          </div>
-        </div>
-        <div class="mdl-grid">
-          <div class="mdl-cell mdl-cell--2-col">
-            <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label textfield-demo">
-              <input class="mdl-textfield__input" type="text" id="filename_textfield" value="file.txt" />
-              <label class="mdl-textfield__label" for="filename_textfield">File name</label>
-            </div>
-          </div>
-          <div class="mdl-cell mdl-cell--2-col">
-            <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect" id="edit_button">Open</button>
-            <div class="mdl-tooltip" for="edit_button">
-              Open up the file in an external editor using <strong>Ballista</strong>
-            </div>
-          </div>
-        </div>
-        <div class="mdl-grid">
-          <div class="mdl-cell mdl-cell--2-col">
-            <p id="status_p">File is not being edited.</p>
           </div>
         </div>
       </main>

--- a/requester/index.js
+++ b/requester/index.js
@@ -33,6 +33,22 @@ function selectedFiles() {
   return selected;
 }
 
+function selectFiles(indices) {
+  var selected = [];
+  var trs = document.querySelectorAll('#file_table tbody tr');
+  for (var i = 0; i < trs.length; i++) {
+    var tr = trs[i];
+    var checkbox = tr.querySelector('input[type = "checkbox"]')
+                       .parentNode.MaterialCheckbox;
+    if (indices.indexOf(i) != -1)
+      checkbox.check();
+    else
+      checkbox.uncheck();
+  }
+
+  selectionChanged();
+}
+
 function selectionChanged() {
   var selected = selectedFiles();
 
@@ -139,6 +155,9 @@ function editButtonClick(index) {
   }
   navigator.serviceWorker.controller.postMessage(
       {type: 'open', file: blob, port: channel.port2}, [channel.port2]);
+
+  // Select the opened file.
+  selectFiles([index]);
 }
 
 function onLoad() {

--- a/requester/index.js
+++ b/requester/index.js
@@ -15,6 +15,72 @@
 // Foreground page
 "use strict";
 
+var files = [
+  {name: 'one.txt'},
+  {name: 'two.txt'},
+];
+
+// Returns the selected filenames.
+function selectedFiles() {
+  var files = [];
+  var trs = document.querySelectorAll('#file_table tbody tr');
+  for (var i = 0; i < trs.length; i++) {
+    var tr = trs[i];
+    if (tr.querySelector('input[type = "checkbox"]').checked) {
+      var fileBox = tr.querySelector('input[type = "text"]');
+      files.push(fileBox.value);
+    }
+  }
+  return files;
+}
+
+function selectionChanged() {
+  var selected = selectedFiles().length > 0;
+  var deleteButton = document.getElementById('delete_files');
+  if (selected)
+    deleteButton.removeAttribute('disabled');
+  else
+    deleteButton.setAttribute('disabled', '');
+}
+
+function generateTableRows() {
+  var table = document.getElementById('file_table');
+  var tbody = table.querySelector('tbody');
+  while (tbody.firstChild)
+    tbody.removeChild(tbody.firstChild);
+
+  for (var i = 0; i < files.length; i++) {
+    var file = files[i];
+    var tr = document.createElement('tr');
+
+    var td1 = document.createElement('td');
+    td1.setAttribute('class', 'mdl-data-table__cell--non-numeric');
+    var textField = document.createElement('div');
+    textField.setAttribute(
+        'class', 'mdl-textfield mdl-js-textfield compact-mdl-textfield');
+    var textFieldInput = document.createElement('input');
+    textFieldInput.setAttribute('class', 'mdl-textfield__input');
+    textFieldInput.setAttribute('type', 'text');
+    textFieldInput.value = file.name;
+    textField.appendChild(textFieldInput);
+    componentHandler.upgradeElement(textField);
+    td1.appendChild(textField);
+    tr.appendChild(td1);
+
+    var td2 = document.createElement('td');
+    td2.setAttribute('class', 'mdl-data-table__cell--non-numeric');
+    var button = document.createElement('button');
+    button.setAttribute('class', 'mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect edit-button');
+    button.appendChild(document.createTextNode('Open'));
+    componentHandler.upgradeElement(button);
+    td2.appendChild(button);
+    tr.appendChild(td2);
+
+    tbody.appendChild(tr);
+  }
+  reUpgradeTable(table, selectionChanged);
+}
+
 // Sets whether the file is open in the external editor.
 function setOpenState(isOpen) {
   var status_p = document.getElementById('status_p');
@@ -70,6 +136,8 @@ function onLoad() {
 
   document.getElementById('edit_button')
       .addEventListener('click', editButtonClick);
+
+  generateTableRows();
 }
 
 window.addEventListener('load', onLoad, false);

--- a/requester/index.js
+++ b/requester/index.js
@@ -15,10 +15,9 @@
 // Foreground page
 "use strict";
 
-var files = [
-  {name: 'one.txt', contents: 'One contents.'},
-  {name: 'two.txt', contents: 'Two contents.'},
-];
+var files = [];
+
+var newFileIndex = 0;
 
 // Returns the selected filenames.
 function selectedFiles() {
@@ -91,6 +90,12 @@ function generateTableRows() {
   reUpgradeTable(table, selectionChanged);
 }
 
+function createNewFile() {
+  var filename = `New File ${++newFileIndex}.txt`;
+  files.push({name: filename, contents: ''});
+  generateTableRows();
+}
+
 // Updates |contents_textfield| with the contents of |file|, asynchronously.
 function updateTextFromFile(file) {
   var contents_textfield = document.getElementById('contents_textfield');
@@ -131,6 +136,9 @@ function onLoad() {
       console.log('ServiceWorker registration failed: ', err);
     });
   }
+
+  document.getElementById('new_file')
+      .addEventListener('click', createNewFile);
 
   generateTableRows();
 }

--- a/requester/index.js
+++ b/requester/index.js
@@ -71,6 +71,7 @@ function generateTableRows() {
     textFieldInput.setAttribute('class', 'mdl-textfield__input');
     textFieldInput.setAttribute('type', 'text');
     textFieldInput.value = file.name;
+    textFieldInput.ballistaIndex = i;
     textField.appendChild(textFieldInput);
     componentHandler.upgradeElement(textField);
     td1.appendChild(textField);
@@ -86,6 +87,8 @@ function generateTableRows() {
     tr.appendChild(td2);
 
     tbody.appendChild(tr);
+
+    textFieldInput.addEventListener('change', onFilenameChanged);
   }
   reUpgradeTable(table, selectionChanged);
 }
@@ -101,6 +104,12 @@ function deleteSelectedFiles() {
   selected.reverse();
   selected.forEach(i => files.splice(i, 1));
   generateTableRows();
+}
+
+function onFilenameChanged(e) {
+  var index = e.target.ballistaIndex;
+  var file = files[index];
+  file.name = e.target.value;
 }
 
 // Updates |contents_textfield| with the contents of |file|, asynchronously.

--- a/requester/index.js
+++ b/requester/index.js
@@ -59,12 +59,16 @@ function selectionChanged() {
     deleteButton.setAttribute('disabled', '');
 
   var contents_textfield = document.getElementById('contents_textfield');
+  var preview_label = document.getElementById('preview_label');
+  var preview_box = document.getElementById('preview_box');
   if (selected.length == 1) {
     // Display a preview of the file's contents.
     contents_textfield.value = files[selected[0]].contents;
-    contents_textfield.style.display = 'block';
+    preview_label.style.display = 'block';
+    preview_box.style.display = 'block';
   } else {
-    contents_textfield.style.display = 'none';
+    preview_label.style.display = 'none';
+    preview_box.style.display = 'none';
   }
 }
 

--- a/requester/index.js
+++ b/requester/index.js
@@ -91,15 +91,6 @@ function generateTableRows() {
   reUpgradeTable(table, selectionChanged);
 }
 
-// Sets whether the file is open in the external editor.
-function setOpenState(isOpen) {
-  var status_p = document.getElementById('status_p');
-  var status_line;
-  status_line =
-      isOpen ? 'File is open in external editor.' : 'File is not being edited.';
-  status_p.innerHTML = status_line;
-}
-
 // Updates |contents_textfield| with the contents of |file|, asynchronously.
 function updateTextFromFile(file) {
   var contents_textfield = document.getElementById('contents_textfield');
@@ -121,9 +112,6 @@ function editButtonClick() {
     var type = data.type;
 
     if (type == 'update') {
-      if (data.openState !== undefined)
-        setOpenState(data.openState);
-
       if (data.file !== undefined)
         updateTextFromFile(data.file);
     }
@@ -143,9 +131,6 @@ function onLoad() {
       console.log('ServiceWorker registration failed: ', err);
     });
   }
-
-  document.getElementById('edit_button')
-      .addEventListener('click', editButtonClick);
 
   generateTableRows();
 }

--- a/requester/index.js
+++ b/requester/index.js
@@ -16,31 +16,41 @@
 "use strict";
 
 var files = [
-  {name: 'one.txt'},
-  {name: 'two.txt'},
+  {name: 'one.txt', contents: 'One contents.'},
+  {name: 'two.txt', contents: 'Two contents.'},
 ];
 
 // Returns the selected filenames.
 function selectedFiles() {
-  var files = [];
+  var selected = [];
   var trs = document.querySelectorAll('#file_table tbody tr');
   for (var i = 0; i < trs.length; i++) {
     var tr = trs[i];
     if (tr.querySelector('input[type = "checkbox"]').checked) {
       var fileBox = tr.querySelector('input[type = "text"]');
-      files.push(fileBox.value);
+      selected.push(files[i]);
     }
   }
-  return files;
+  return selected;
 }
 
 function selectionChanged() {
-  var selected = selectedFiles().length > 0;
+  var selected = selectedFiles();
+
   var deleteButton = document.getElementById('delete_files');
-  if (selected)
+  if (selected.length > 0)
     deleteButton.removeAttribute('disabled');
   else
     deleteButton.setAttribute('disabled', '');
+
+  var contents_textfield = document.getElementById('contents_textfield');
+  if (selected.length == 1) {
+    // Display a preview of the file's contents.
+    contents_textfield.value = selected[0].contents;
+    contents_textfield.style.display = 'block';
+  } else {
+    contents_textfield.style.display = 'none';
+  }
 }
 
 function generateTableRows() {

--- a/requester/index.js
+++ b/requester/index.js
@@ -15,7 +15,9 @@
 // Foreground page
 "use strict";
 
-var files = [];
+var files = [
+  {name: 'file.txt', contents: 'You can edit this file using Ballista!\n'},
+];
 
 var newFileIndex = 0;
 

--- a/requester/index.js
+++ b/requester/index.js
@@ -89,6 +89,7 @@ function generateTableRows() {
     tbody.appendChild(tr);
 
     textFieldInput.addEventListener('change', onFilenameChanged);
+    button.addEventListener('click', editButtonClick.bind(undefined, i));
   }
   reUpgradeTable(table, selectionChanged);
 }
@@ -121,11 +122,9 @@ function updateTextFromFile(file) {
       });
 }
 
-function editButtonClick() {
-  var contents_textfield = document.getElementById('contents_textfield');
-  var contents = contents_textfield.value;
-  var filename = document.getElementById('filename_textfield').value;
-  var file = new File([contents], filename, {type: "text/plain"});
+function editButtonClick(index) {
+  var file = files[index];
+  var blob = new File([file.contents], file.name, {type: "text/plain"});
 
   var channel = new MessageChannel();
   channel.port1.onmessage = event => {
@@ -138,7 +137,7 @@ function editButtonClick() {
     }
   }
   navigator.serviceWorker.controller.postMessage(
-      {type: 'open', file: file, port: channel.port2}, [channel.port2]);
+      {type: 'open', file: blob, port: channel.port2}, [channel.port2]);
 }
 
 function onLoad() {

--- a/requester/index.js
+++ b/requester/index.js
@@ -19,7 +19,7 @@ var files = [];
 
 var newFileIndex = 0;
 
-// Returns the selected filenames.
+// Returns the indices of the selected files.
 function selectedFiles() {
   var selected = [];
   var trs = document.querySelectorAll('#file_table tbody tr');
@@ -27,7 +27,7 @@ function selectedFiles() {
     var tr = trs[i];
     if (tr.querySelector('input[type = "checkbox"]').checked) {
       var fileBox = tr.querySelector('input[type = "text"]');
-      selected.push(files[i]);
+      selected.push(i);
     }
   }
   return selected;
@@ -45,7 +45,7 @@ function selectionChanged() {
   var contents_textfield = document.getElementById('contents_textfield');
   if (selected.length == 1) {
     // Display a preview of the file's contents.
-    contents_textfield.value = selected[0].contents;
+    contents_textfield.value = files[selected[0]].contents;
     contents_textfield.style.display = 'block';
   } else {
     contents_textfield.style.display = 'none';
@@ -96,6 +96,13 @@ function createNewFile() {
   generateTableRows();
 }
 
+function deleteSelectedFiles() {
+  var selected = selectedFiles();
+  selected.reverse();
+  selected.forEach(i => files.splice(i, 1));
+  generateTableRows();
+}
+
 // Updates |contents_textfield| with the contents of |file|, asynchronously.
 function updateTextFromFile(file) {
   var contents_textfield = document.getElementById('contents_textfield');
@@ -136,6 +143,9 @@ function onLoad() {
       console.log('ServiceWorker registration failed: ', err);
     });
   }
+
+  document.getElementById('delete_files')
+      .addEventListener('click', deleteSelectedFiles);
 
   document.getElementById('new_file')
       .addEventListener('click', createNewFile);

--- a/requester/index.js
+++ b/requester/index.js
@@ -113,12 +113,13 @@ function onFilenameChanged(e) {
   file.name = e.target.value;
 }
 
-// Updates |contents_textfield| with the contents of |file|, asynchronously.
-function updateTextFromFile(file) {
-  var contents_textfield = document.getElementById('contents_textfield');
-  return readBlobAsText(file)
+// Updates the local file |index| with the contents of |blob|, asynchronously.
+function updateFileFromBlob(index, blob) {
+  return readBlobAsText(blob)
       .then(text => {
-        contents_textfield.value = text;
+        files[index].contents = text;
+        // Refresh the contents textfield if selected.
+        selectionChanged();
       });
 }
 
@@ -133,7 +134,7 @@ function editButtonClick(index) {
 
     if (type == 'update') {
       if (data.file !== undefined)
-        updateTextFromFile(data.file);
+        updateFileFromBlob(index, data.file);
     }
   }
   navigator.serviceWorker.controller.postMessage(


### PR DESCRIPTION
This helps demonstrate the file editing use case better. Instead of presenting a file editor interface, it now shows a file list, allowing the user to create, delete and edit files (using an external Ballista editor). The files are just stored in memory (they are lost upon refreshing the page).
