### PR TITLE
Open a tab in the handler before sending on actions to handle.

### DIFF
--- a/handler/sw.js
+++ b/handler/sw.js
@@ -69,7 +69,7 @@ self.addEventListener('fetch', event => {
 // worker. Returns a promise. Rejects the promise if none found.
 function findLastTopLevelClient() {
   return clients.matchAll().then(allClients => {
-    for (var i = allClients.length - 1; i >= 0; i--) {
+    for (var i = 0; i < allClients.length; i++) {
       if (allClients[i].frameType == 'top-level')
         return allClients[i];
     }

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -23,8 +23,8 @@ This includes newer versions of Google Chrome / Chromium and Mozilla Firefox.
   need to remain open to receive updates).
 * Not able to send actions to native applications.
 * Not possible to use `clients.openWindow` from the `'action'` event handler
-  (when the handler's service worker receives an action). This means your apps
-  need to handle the action in an existing tab, rather than opening a new tab.
+  (when the handler's service worker receives an action). The polyfill will
+  automatically open the handler in a new tab for you.
 
 ## Usage instructions
 

--- a/polyfill/ballista-polyfill.js
+++ b/polyfill/ballista-polyfill.js
@@ -96,7 +96,7 @@ if (self.WorkerNavigator !== undefined) {
   // worker. Returns a promise. Rejects the promise if none found.
   findLastTopLevelClient = () => {
     return clients.matchAll().then(allClients => {
-      for (var i = allClients.length - 1; i >= 0; i--) {
+      for (var i = 0; i < allClients.length; i++) {
         if (allClients[i].frameType == 'top-level') {
           return allClients[i];
         }

--- a/polyfill/proxy-iframe.html
+++ b/polyfill/proxy-iframe.html
@@ -21,8 +21,15 @@ limitations under the License.
 // it onto the handler's service worker. The iframe does not need to remain
 // alive after the exchange has taken place.
 window.onmessage = function(e) {
+  // Pop open a new tab. Note: The final API should not do this; instead the
+  // user's code should use |clients.openWindow()| to open a window if desired.
+  // Since this isn't possible in the polyfill, we just pop open a tab on the
+  // user's behalf.
+  var w = window.open(e.data.url);
   var port = e.data.port;
-  navigator.serviceWorker.controller.postMessage(
-      {type: 'connect', port: port}, [port]);
+  w.addEventListener('load', e => {
+    navigator.serviceWorker.controller.postMessage(
+        {type: 'connect', port: port}, [port]);
+  }, true);
 };
 </script>

--- a/proxy/choose.js
+++ b/proxy/choose.js
@@ -92,7 +92,7 @@ function populateUI() {
 function sendPortToHandler(url, port) {
   var iframe = document.querySelector('#handler_iframe');
   iframe.onload = function(event) {
-    iframe.contentWindow.postMessage({port: port}, '*', [port]);
+    iframe.contentWindow.postMessage({port: port, url: url}, '*', [port]);
   };
 
   iframe.setAttribute('src', url + kProxyUrlSuffix);

--- a/requester/README.md
+++ b/requester/README.md
@@ -23,8 +23,7 @@ You can try it out locally using the App Engine dev appserver.
 3. Run the dev appserver: `dev_appserver.py proxy.yaml handler.yaml
    requester.yaml`.
 4. Open the [handler](http://localhost:8081) in a supported browser. You will be
-   prompted to register this site as an action handler. Click "OK". You need to
-   keep the handler app open (due to limitations of the polyfill).
+   prompted to register this site as an action handler. Click "OK".
 5. You can view and delete handler registrations in the [polyfill control
    panel](http://localhost:8000).
 6. Open the [requester](http://localhost:8082) in another tab.


### PR DESCRIPTION
This means you don't need to have a tab handy before sending a request.

This also changes the order in which tabs are iterated to find which one to send the request to, so that the newly opened tab is used. The tab iteration order for working out which requester page to put the chooser dialog in has also been made consistent.
